### PR TITLE
Add single column card layout at small width

### DIFF
--- a/src/components/GitHubItem.re
+++ b/src/components/GitHubItem.re
@@ -24,6 +24,7 @@ let styles = Css.(Styles.({
     overflow(`hidden),
     paddingTop @@ em(0.25),
     textOverflow(`ellipsis),
+    unsafe("wordBreak", "break-word"),
   ],
   "link": [
     fontSize @@ em(1.05),

--- a/src/components/GitHubList.re
+++ b/src/components/GitHubList.re
@@ -11,9 +11,12 @@ let component = ReasonReact.statelessComponent("GitHubList");
 let childStyle = Css.(Styles.([
   display(`grid),
   gridGap @@ px(10),
-  unsafe("gridTemplateColumns", "repeat(2, minmax(50%, 1fr))"),
+  gridTemplateColumns([fr(1.)]),
+  media(breakpoint(Large), [
+    unsafe("gridTemplateColumns", "repeat(3, 1fr)"),
+  ]),
   media(breakpoint(Small), [
-    unsafe("gridTemplateColumns", "repeat(3, minmax(33%, 1fr))")
+    unsafe("gridTemplateColumns", "repeat(2, 1fr)"),
   ]),
 ]));
 

--- a/src/pages/index.re
+++ b/src/pages/index.re
@@ -31,7 +31,7 @@ let className = Css.(Styles.(
   style([
     padding2(~v=em(2.), ~h=em(1.)),
     media(breakpoint(Large), [
-      padding2(~v=em(4.), ~h=em(6.))
+      padding2(~v=em(4.), ~h=em(2.))
     ]),
   ])
 ));

--- a/src/utils/Styles.re
+++ b/src/utils/Styles.re
@@ -6,7 +6,7 @@ let makeRGBA = Css.rgba(17, 17, 17);
 
 let breakpoint = size =>
   switch size {
-    | Large => "only screen and (min-width: 1280px)"
+    | Large => "only screen and (min-width: 1200px)"
     | Small => "only screen and (min-width: 768px)"
   };
 


### PR DESCRIPTION
- Change Large breakpoint from 1280px -> 1200px
- Cut right/left padding by 2/3rds on Large breakpoint
- Wrap long descriptions at small widths